### PR TITLE
fix(docs): Add note to say Windows isn't supported to avoid a user wasting time spinning up the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Padawan.sublime
 ===============
 
+**No plans for Windows support**
+
 Padawan.sublime is a Sublime Text 3 plugin for [padawan.php server
 ](https://github.com/mkusher/padawan.php), a smart PHP code
 completion server for Composer projects.


### PR DESCRIPTION
fix(docs): Add note to say Windows isn't supported to avoid a user wasting time spinning up the plugin.

Referring to:
https://github.com/padawan-php/padawan.sublime/issues/1